### PR TITLE
Add dark mode support and mobile upload enhancements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,44 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { FileConverter } from './components/FileConverter';
 import { Header } from './components/Header';
 import { Footer } from './components/Footer';
 
 function App() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      const storedTheme = window.localStorage.getItem('theme');
+      if (storedTheme === 'light' || storedTheme === 'dark') {
+        return storedTheme;
+      }
+
+      if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark';
+      }
+    }
+
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('theme', theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
   return (
-    <div className="min-h-screen bg-primary-50">
-      <Header />
+    <div className="min-h-screen bg-primary-50 text-primary-900 transition-colors duration-200 dark:bg-neutral-950 dark:text-neutral-100">
+      <Header theme={theme} onToggleTheme={toggleTheme} />
       <main className="container mx-auto px-4 py-8">
         <FileConverter />
       </main>

--- a/frontend/src/components/FileConverter.tsx
+++ b/frontend/src/components/FileConverter.tsx
@@ -38,7 +38,7 @@ export const FileConverter: React.FC = () => {
     }
   }, [files.length]);
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+  const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
     onDrop,
     accept: {
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
@@ -136,27 +136,37 @@ export const FileConverter: React.FC = () => {
       <div className="card">
         <div
           {...getRootProps()}
-          className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
-            isDragActive 
-              ? 'border-primary-500 bg-primary-100' 
-              : 'border-primary-300 hover:border-primary-400'
+          className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors duration-200 ${
+            isDragActive
+              ? 'border-primary-500 bg-primary-100 dark:border-primary-400 dark:bg-neutral-800/70'
+              : 'border-primary-300 hover:border-primary-400 dark:border-neutral-700 dark:hover:border-neutral-500 dark:bg-neutral-900/40'
           }`}
         >
           <input {...getInputProps()} />
           <Upload className="w-12 h-12 text-primary-400 mx-auto mb-4" />
           {isDragActive ? (
-            <p className="text-lg text-primary-600">Drop the files here...</p>
+            <p className="text-lg text-primary-600 dark:text-primary-200">Drop the files here...</p>
           ) : (
             <div>
-              <p className="text-lg text-primary-700 mb-2">
+              <p className="text-lg text-primary-700 dark:text-primary-100 mb-2">
                 Drag & drop files here, or click to select
               </p>
-              <p className="text-sm text-primary-500">
+              <p className="text-sm text-primary-500 dark:text-primary-200">
                 Supports DOCX, XLSX, PPTX, TXT, PDF, JPEG, PNG, WebP, TIFF, GIF, BMP
               </p>
             </div>
           )}
         </div>
+        <p className="mt-4 text-sm text-primary-500 dark:text-primary-200">
+          🔒 Your files are never stored. Instant, private, and secure conversion.
+        </p>
+        <button
+          type="button"
+          onClick={open}
+          className="btn-primary mt-4 w-full sm:hidden"
+        >
+          Browse Files
+        </button>
       </div>
 
       {/* File List */}
@@ -170,7 +180,7 @@ export const FileConverter: React.FC = () => {
       {/* Format Selection */}
       {files.length > 0 && (
         <div className="card">
-          <h3 className="text-lg font-semibold text-primary-900 mb-4">Select Output Format</h3>
+          <h3 className="text-lg font-semibold text-primary-900 dark:text-primary-100 mb-4">Select Output Format</h3>
           <FormatSelector
             availableFormats={getCommonFormats()}
             selectedFormat={targetFormat}
@@ -180,27 +190,25 @@ export const FileConverter: React.FC = () => {
       )}
 
       {/* Convert Button */}
-      {files.length > 0 && targetFormat && (
-        <div className="text-center">
-          <button
-            onClick={handleConvert}
-            disabled={isConverting}
-            className="btn-primary text-lg px-8 py-3"
-          >
-            {isConverting ? (
-              <>
-                <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                Converting...
-              </>
-            ) : (
-              <>
-                <FileText className="w-5 h-5 mr-2" />
-                Convert Files
-              </>
-            )}
-          </button>
-        </div>
-      )}
+      <div className="text-center">
+        <button
+          onClick={handleConvert}
+          disabled={isConverting || files.length === 0 || !targetFormat}
+          className="btn-primary text-lg px-8 py-3 inline-flex items-center justify-center"
+        >
+          {isConverting ? (
+            <>
+              <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+              Converting...
+            </>
+          ) : (
+            <>
+              <FileText className="w-5 h-5 mr-2" />
+              Convert Files
+            </>
+          )}
+        </button>
+      </div>
 
       {/* Error Message */}
       {error && (

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 export const Footer: React.FC = () => {
   return (
-    <footer className="bg-primary-800 border-t border-primary-700 mt-16">
+    <footer className="bg-primary-800 border-t border-primary-700 mt-16 dark:bg-neutral-950 dark:border-neutral-800">
       <div className="container mx-auto px-4 py-6">
-        <div className="text-center text-sm text-primary-200">
+        <div className="text-center text-sm text-primary-200 dark:text-neutral-300">
           <p>&copy; 2025 Catalyst Works. Convert documents and images with ease.</p>
-          <p className="mt-1 text-primary-300">Supports DOCX, XLSX, PPTX, TXT, PDF, JPEG, PNG, WebP, TIFF, GIF, BMP</p>
+          <p className="mt-1 text-primary-300 dark:text-neutral-400">Supports DOCX, XLSX, PPTX, TXT, PDF, JPEG, PNG, WebP, TIFF, GIF, BMP</p>
         </div>
       </div>
     </footer>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,17 +1,32 @@
 import React from 'react';
-import { FileText, Zap } from 'lucide-react';
+import { FileText, Moon, Sun } from 'lucide-react';
 
-export const Header: React.FC = () => {
+type HeaderProps = {
+  theme: 'light' | 'dark';
+  onToggleTheme: () => void;
+};
+
+export const Header: React.FC<HeaderProps> = ({ theme, onToggleTheme }) => {
+  const isDark = theme === 'dark';
+
   return (
-    <header className="header-gradient shadow-lg border-b border-primary-700">
-      <div className="container mx-auto px-4 py-6">
+    <header className="header-gradient shadow-lg border-b border-primary-700 dark:border-neutral-800">
+      <div className="container mx-auto px-4 py-6 relative">
+        <button
+          type="button"
+          onClick={onToggleTheme}
+          className="absolute right-4 top-4 inline-flex items-center justify-center rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/60 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
+          aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+        >
+          {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+        </button>
         <div className="flex items-center justify-center">
           <div className="flex items-center space-x-4">
             <div className="flex items-center justify-center w-14 h-14 bg-accent-500 rounded-xl shadow-lg">
               <FileText className="w-7 h-7 text-white" />
             </div>
-            <div className="text-center">
-              <h1 className="text-3xl font-bold text-white">File Converter</h1>
+            <div className="text-center text-white">
+              <h1 className="text-3xl font-bold">File Converter</h1>
               <p className="text-accent-200 text-sm font-medium">by Catalyst Works</p>
               <p className="text-primary-200 text-xs">Fast & Simple File Conversion</p>
             </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,33 +8,33 @@
   }
   
   body {
-    @apply bg-primary-50 text-primary-900;
+    @apply bg-primary-50 text-primary-900 dark:bg-neutral-950 dark:text-neutral-100 transition-colors duration-200;
   }
 }
 
 @layer components {
   .btn-primary {
-    @apply bg-primary-700 hover:bg-primary-800 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm;
+    @apply bg-primary-700 hover:bg-primary-800 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm dark:bg-primary-500 dark:hover:bg-primary-400 dark:text-neutral-900;
   }
-  
+
   .btn-secondary {
-    @apply bg-neutral-200 hover:bg-neutral-300 text-neutral-800 font-medium py-2 px-4 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm;
+    @apply bg-neutral-200 hover:bg-neutral-300 text-neutral-800 font-medium py-2 px-4 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:text-neutral-100;
   }
-  
+
   .btn-accent {
-    @apply bg-accent-500 hover:bg-accent-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm;
+    @apply bg-accent-500 hover:bg-accent-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm dark:text-neutral-900;
   }
-  
+
   .input-field {
-    @apply w-full px-3 py-2 border border-primary-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white;
+    @apply w-full px-3 py-2 border border-primary-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100;
   }
-  
+
   .card {
-    @apply bg-white rounded-lg shadow-sm border border-primary-200 p-6;
+    @apply bg-white rounded-lg shadow-sm border border-primary-200 p-6 dark:bg-neutral-900 dark:border-neutral-700;
   }
-  
+
   .header-gradient {
-    @apply bg-gradient-to-r from-primary-800 to-primary-900;
+    @apply bg-gradient-to-r from-primary-800 to-primary-900 dark:from-neutral-900 dark:to-neutral-950;
   }
 }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    globals: true,
   },
 })
 


### PR DESCRIPTION
## Summary
- add client-side theme management with a header toggle and dark mode styling updates
- show a privacy notice and mobile-friendly browse button alongside the uploader, keeping the convert button accessible
- configure Tailwind and Vitest for dark mode while expanding shared component styles for the new theme

## Testing
- npm --prefix frontend run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ce86895ef083288974bd2a13e561ad