### PR TITLE
Add primary CTA and dropdown format selector

### DIFF
--- a/frontend/src/__tests__/components/FileConverter.test.tsx
+++ b/frontend/src/__tests__/components/FileConverter.test.tsx
@@ -21,7 +21,8 @@ describe('FileConverter', () => {
     // This would require more complex setup with file selection
     // For now, just test the basic render
     render(<FileConverter />);
-    expect(screen.getByRole('button', { name: /convert files/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /convert now/i })).toBeInTheDocument();
+    expect(screen.getByText('Fast & secure conversion in seconds.')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/FormatSelector.tsx
+++ b/frontend/src/components/FormatSelector.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Check } from 'lucide-react';
 
 interface FormatSelectorProps {
   availableFormats: string[];
@@ -13,12 +12,12 @@ export const FormatSelector: React.FC<FormatSelectorProps> = ({
   onFormatChange
 }) => {
   const formatLabels: Record<string, string> = {
-    'pdf': 'PDF',
-    'png': 'PNG',
-    'jpeg': 'JPEG',
-    'jpg': 'JPEG',
-    'webp': 'WebP',
-    'tiff': 'TIFF'
+    pdf: 'PDF',
+    png: 'PNG',
+    jpeg: 'JPEG',
+    jpg: 'JPEG',
+    webp: 'WebP',
+    tiff: 'TIFF'
   };
 
   if (availableFormats.length === 0) {
@@ -30,30 +29,27 @@ export const FormatSelector: React.FC<FormatSelectorProps> = ({
   }
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
-      {availableFormats.map((format) => (
-        <button
-          key={format}
-          onClick={() => onFormatChange(format)}
-          className={`relative p-4 border-2 rounded-lg text-center transition-all ${
-            selectedFormat === format
-              ? 'border-primary-500 bg-primary-100 text-primary-700'
-              : 'border-primary-200 hover:border-primary-300 text-primary-700'
-          }`}
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-primary-700" htmlFor="target-format">
+        Choose output format
+      </label>
+      <div className="relative">
+        <select
+          id="target-format"
+          value={selectedFormat || availableFormats[0]}
+          onChange={(event) => onFormatChange(event.target.value)}
+          className="w-full appearance-none rounded-lg border-2 border-primary-200 bg-white px-4 py-3 text-primary-700 focus:border-primary-500 focus:outline-none"
         >
-          {selectedFormat === format && (
-            <div className="absolute top-2 right-2">
-              <Check className="w-4 h-4 text-primary-600" />
-            </div>
-          )}
-          <div className="font-medium">
-            {formatLabels[format] || format.toUpperCase()}
-          </div>
-          <div className="text-xs text-primary-500 mt-1">
-            .{format}
-          </div>
-        </button>
-      ))}
+          {availableFormats.map((format) => (
+            <option key={format} value={format}>
+              {formatLabels[format] || format.toUpperCase()}
+            </option>
+          ))}
+        </select>
+        <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-primary-400">
+          ▾
+        </span>
+      </div>
     </div>
   );
 };

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
+    globals: true,
     setupFiles: ['./src/test/setup.ts'],
   },
 })


### PR DESCRIPTION
## Summary
- add a prominent "Convert Now" button beneath the upload area with supporting microcopy
- replace the grid format selector with a dropdown that defaults to common formats like PDF
- adjust tests and Vitest configuration to reflect the updated UI

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ce8675b9ec83288dc42b4b7945fc1a